### PR TITLE
fix route annotations to remove deprecation warnings

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,3 +14,7 @@ services:
     App\Controller\:
         resource: '../src/Controller'
         tags: ['controller.service_arguments']
+
+sensio_framework_extra:
+    router:
+        annotations: false

--- a/src/Controller/ArticleController.php
+++ b/src/Controller/ArticleController.php
@@ -3,8 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Article;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Workflow\Exception\ExceptionInterface;
@@ -25,8 +24,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * @Route("/create", name="article_create")
-     * @Method("POST")
+     * @Route("/create", methods={"POST"}, name="article_create")
      */
     public function createAction(Request $request)
     {
@@ -50,8 +48,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * @Route("/apply-transition/{id}", name="article_apply_transition")
-     * @Method("POST")
+     * @Route("/apply-transition/{id}", methods={"POST"}, name="article_apply_transition")
      */
     public function applyTransitionAction(Request $request, Article $article)
     {
@@ -70,8 +67,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * @Route("/reset-marking/{id}", name="article_reset_marking")
-     * @Method("POST")
+     * @Route("/reset-marking/{id}", methods={"POST"}, name="article_reset_marking")
      */
     public function resetMarkingAction(Article $article)
     {

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 
 class HomepageController extends Controller

--- a/src/Controller/TaskController.php
+++ b/src/Controller/TaskController.php
@@ -3,8 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\Task;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Workflow\Exception\ExceptionInterface;
@@ -25,8 +24,7 @@ class TaskController extends Controller
     }
 
     /**
-     * @Route("/create", name="task_create")
-     * @Method("POST")
+     * @Route("/create", methods={"POST"}, name="task_create")
      */
     public function createAction(Request $request)
     {
@@ -50,8 +48,7 @@ class TaskController extends Controller
     }
 
     /**
-     * @Route("/apply-transition/{id}", name="task_apply_transition")
-     * @Method("POST")
+     * @Route("/apply-transition/{id}", methods={"POST"}, name="task_apply_transition")
      */
     public function applyTransitionAction(Request $request, Task $task)
     {
@@ -70,8 +67,7 @@ class TaskController extends Controller
     }
 
     /**
-     * @Route("/reset-marking/{id}", name="task_reset_marking")
-     * @Method("POST")
+     * @Route("/reset-marking/{id}", methods={"POST"}, name="task_reset_marking")
      */
     public function resetMarkingAction(Task $task)
     {


### PR DESCRIPTION
Uses the Symfony routing component rather than SensioExtraFramework.